### PR TITLE
docs: add realistic MVP planning guidance to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,42 @@
 
 # Shoot 'em All - MVP Description
 
+## Practical Scope Recommendation (for a first playable build)
+
+To keep development realistic and shippable, split work into three milestones:
+
+1. **M1 - Playable Core (1-2 weeks)**
+   - One player ship, one weapon (Blaster), and 2 enemy types
+   - Survive loop with spawning, collisions, HP, death, and restart
+   - Basic XP gain and 3 level-up choices
+
+2. **M2 - Retention Layer (1-2 weeks)**
+   - Add 2 more weapons from the current list
+   - Add one mini-boss and one simple meta currency upgrade
+   - Add settings (audio, controls) and save/load for upgrades
+
+3. **M3 - Polish + Validation (1 week)**
+   - Visual/audio feedback pass (hit flash, simple particles, SFX)
+   - Balance pass (enemy HP/speed curves, weapon tuning)
+   - Small playtest and bug-fix sprint
+
+### What to postpone until after MVP
+
+Move these ideas to a post-launch backlog so they don't block release:
+- Story mode, weekly events, community events
+- Companion/drone system
+- Dynamic environment hazards (solar flares, gravity wells)
+- Deep achievement + leaderboard ecosystem
+- Multiple ship classes with unique skill trees
+
+### Success criteria for MVP
+
+- New player can start a run in **under 20 seconds**
+- Stable 10-minute run with no game-breaking bugs
+- At least 1 meaningful build decision every 2-3 levels
+- Clear death summary screen with XP/Gold earned
+- Consistent performance on target hardware (define FPS target)
+
 ## Core Gameplay
 
 ### Basic Mechanics


### PR DESCRIPTION
### Motivation
- The README contained many broad ideas but lacked a concise, actionable plan to ship a first playable build within a short timeframe.
- The change aims to reduce scope creep and clarify which features should be postponed to make the project more shippable.

### Description
- Added a `Practical Scope Recommendation` section that splits work into three milestones: `M1` (playable core), `M2` (retention layer), and `M3` (polish + validation).
- Added a `What to postpone until after MVP` backlog to keep complex features off the critical path.
- Added measurable `Success criteria for MVP` (quick start, stable run, meaningful build choices, death summary, and performance target).
- Inserted the new guidance near the top of `README.md` to make planning visible to contributors and reviewers.

### Testing
- Verified the patch application step with `apply_patch` which completed successfully.
- Confirmed the updated `README.md` content using `sed -n '1,240p' README.md` which showed the new milestone and success criteria sections.
- Displayed the file with `nl -ba README.md | sed -n '1,120p'` to validate line placement and formatting of the new content.
- Recorded PR metadata via `make_pr` which returned the generated title and body for the pull request.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fb378581c83229f23d9771d22e163)